### PR TITLE
단위 도장 페이지 연습게임 베스트 스코어 표시

### DIFF
--- a/src/components/Dani/BestScore.svelte
+++ b/src/components/Dani/BestScore.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-    import { type PlaydataType } from "../../types";
+    import { type PlaydataType } from '../../types'
 
-    export let playdata: Promise<PlaydataType>;
+    export let playdata: Promise<PlaydataType>
 
-    const keys:(keyof PlaydataType)[] = ["good", "pound", "ok", "combo", "ng", "hit"]
+    const keys: Array<keyof PlaydataType> = ['good', 'pound', 'ok', 'combo', 'ng', 'hit']
 </script>
 
 {#await playdata}

--- a/src/components/Dani/BestScore.svelte
+++ b/src/components/Dani/BestScore.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+    export let playdata: {
+        score: number;
+        good: number;
+        ok: number;
+        ng: number;
+        pound: number;
+        combo: number;
+        hit:number;
+    };
+
+    const keys:(keyof typeof playdata)[] = ["good", "pound", "ok", "combo", "ng", "hit"]
+</script>
+
+<div class="container">
+    <div class="title">
+        연주 게임 베스트 스코어
+    </div>
+    <div class="score">
+        {playdata.score}점
+    </div>
+    {#each keys as key}
+    <div class="data">
+        <img src={`image/sp/640/score_name_${key}_640.png`} alt="icon">
+        {playdata[key]}회
+    </div>
+    {/each}
+</div>
+
+<style>
+    .container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+
+        justify-content: center;
+        column-gap: 10px;
+        row-gap: 3px;
+    }
+
+    .title{
+        width:100%;
+        text-align: center;
+        font-weight: bold;
+    }
+
+    .score{
+        width: 240px;
+        height:35px;
+        background-image: url('image/sp/640/score_back_0_640.png');
+        background-size: 100% 100%;
+
+        color:white;
+        font-weight: bold;
+        font-size: 18px;
+
+        display:flex;
+        align-items: center;
+        justify-content: center;
+
+        padding-top: 3px;
+    }
+
+    .data{
+        width:117px;
+
+        display:flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+
+        background-color: white;
+
+        box-sizing: border-box;
+        padding-inline: 2px;
+    }
+
+    .data > img{
+        width:auto;
+        height:18px;
+    }
+</style>

--- a/src/components/Dani/BestScore.svelte
+++ b/src/components/Dani/BestScore.svelte
@@ -23,8 +23,6 @@
     </div>
     {/each}
 </div>
-{:catch}
-<div></div>
 {/await}
 
 <style>

--- a/src/components/Dani/BestScore.svelte
+++ b/src/components/Dani/BestScore.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
-    export let playdata: {
-        score: number;
-        good: number;
-        ok: number;
-        ng: number;
-        pound: number;
-        combo: number;
-        hit:number;
-    };
+    import { type PlaydataType } from "../../types";
 
-    const keys:(keyof typeof playdata)[] = ["good", "pound", "ok", "combo", "ng", "hit"]
+    export let playdata: Promise<PlaydataType>;
+
+    const keys:(keyof PlaydataType)[] = ["good", "pound", "ok", "combo", "ng", "hit"]
 </script>
 
+{#await playdata}
+로딩중...
+{:then playdata}
 <div class="container">
     <div class="title">
         연주 게임 베스트 스코어
@@ -26,6 +23,9 @@
     </div>
     {/each}
 </div>
+{:catch}
+<div></div>
+{/await}
 
 <style>
     .container {

--- a/src/injection.ts
+++ b/src/injection.ts
@@ -22,7 +22,7 @@ const runHiroba = async (): Promise<void> => {
     'favorite_song_select.php': favorite_song_select,
     'score_detail.php': score_detail,
     'select_song.php': select_song,
-    "dan_detail.php": dani
+    'dan_detail.php': dani
   }
 
   await scriptMap[page]?.()

--- a/src/injection.ts
+++ b/src/injection.ts
@@ -6,6 +6,7 @@ import diffchart from './injections/diffchart'
 import score_detail from './injections/score_detail'
 import select_song from './injections/select_song'
 import i18n from './injections/i18n'
+import dani from './injections/dani'
 
 const runHiroba = async (): Promise<void> => {
   const path = window.location.href.split('/').slice(3).join('/')
@@ -20,7 +21,8 @@ const runHiroba = async (): Promise<void> => {
     'index.php': index,
     'favorite_song_select.php': favorite_song_select,
     'score_detail.php': score_detail,
-    'select_song.php': select_song
+    'select_song.php': select_song,
+    "dan_detail.php": dani
   }
 
   await scriptMap[page]?.()

--- a/src/injections/dani.ts
+++ b/src/injections/dani.ts
@@ -16,7 +16,7 @@ export default async function dani (): Promise<void> {
         playdata: (async () => {
         // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
           const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim()
-          const songNo = songdata.getSongDataByTitle(songTitle)?.[0]
+          const songNo = songdata.getSongNoByTitle(songTitle)
           const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, '$1')
 
           // db에 해당 곡명을 가진 곡에 대한 데이터가 없으면 종료

--- a/src/injections/dani.ts
+++ b/src/injections/dani.ts
@@ -1,63 +1,64 @@
-import { type PlaydataType, type SongData } from "../types";
-import BestScore from "../components/Dani/BestScore.svelte";
+import { type PlaydataType, type SongData } from '../types'
+import BestScore from '../components/Dani/BestScore.svelte'
 
-export default async function dani(): Promise<void> {
-    if ((new URL(window.location.href)).pathname !== "/dan_detail.php") return;
+export default async function dani (): Promise<void> {
+  if ((new URL(window.location.href)).pathname !== '/dan_detail.php') return
 
-    const boxes = [...document.querySelectorAll('.contentBox:not(.errorArea)')];
-    const songdata = (await import('../songdata.json') as any).default as Record<string, SongData>
+  const boxes = [...document.querySelectorAll('.contentBox:not(.errorArea)')]
+  const songdata = (await import('../songdata.json') as any).default as Record<string, SongData>
 
-    boxes.map((box) => {
-        const bestscore = new BestScore({
-            target: box,
-            props: {
-                playdata: (async () => {
-                    const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim();
-                    console.log(songTitle);
-                    const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo;
-                    const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, "$1")
+  boxes.forEach((box) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const bestscore = new BestScore({
+      target: box,
+      props: {
+        playdata: (async () => {
+        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+          const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim()
+          console.log(songTitle)
+          const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo
+          const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, '$1')
 
-                    //db에 해당 곡명을 가진 곡에 대한 데이터가 없으면 종료
-                    if (songNo === undefined || difficulty === undefined) throw new Error();
+          // db에 해당 곡명을 가진 곡에 대한 데이터가 없으면 종료
+          if (songNo === undefined || difficulty === undefined) throw new Error()
 
-                    let response: string;
-                    try {
-                        response = await (await fetch(`/score_detail.php?song_no=${songNo}&level=${difficulty}`)).text()
-                    }
-                    catch {
-                        //요청에 문제가 생기면 종료
-                        throw new Error();
-                    }
+          let response: string
+          try {
+            response = await (await fetch(`/score_detail.php?song_no=${songNo}&level=${difficulty}`)).text()
+          } catch {
+            // 요청에 문제가 생기면 종료
+            throw new Error()
+          }
 
-                    const dom = document.createElement('div');
-                    dom.innerHTML = response;
-                    const scoreDetailTable = dom.querySelector('.scoreDetailTable');
+          const dom = document.createElement('div')
+          dom.innerHTML = response
+          const scoreDetailTable = dom.querySelector('.scoreDetailTable')
 
-                    //scoreDetailTable이 없으면 종료
-                    if (scoreDetailTable === null) throw new Error();
-                    /*
+          // scoreDetailTable이 없으면 종료
+          if (scoreDetailTable === null) throw new Error()
+          /*
                     한번도 플레이한 적이 없으면 종료
                     그냥 0점으로 표시할거면 밑줄 지우세요
                     */
-                    if (dom.querySelector('.contentBox.errorArea')) throw new Error();
+          if (dom.querySelector('.contentBox.errorArea') === null) throw new Error()
 
-                    const playdata:PlaydataType = {
-                        score: parseInt((dom.querySelector('.high_score') as HTMLElement).innerText.trim().replace('点', '')),
-                        good: parseInt((dom.querySelector('.good_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-                        ok: parseInt((dom.querySelector('.ok_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-                        ng: parseInt((dom.querySelector('.ng_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-                        pound: parseInt((dom.querySelector('.pound_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-                        combo: parseInt((dom.querySelector('.combo_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-                        hit: 0
-                    }
+          const playdata: PlaydataType = {
+            /* eslint-disable */
+            score: parseInt((dom.querySelector('div.high_score') as HTMLElement).innerText.trim().replace('点', '') as string),
+            good: parseInt((dom.querySelector('div.good_cnt') as HTMLElement).innerText.trim().replace('回', '') as string),
+            ok: parseInt((dom.querySelector('div.ok_cnt') as HTMLElement).innerText.trim().replace('回', '') as string),
+            ng: parseInt((dom.querySelector('div.ng_cnt') as HTMLElement).innerText.trim().replace('回', '') as string),
+            pound: parseInt((dom.querySelector('div.pound_cnt') as HTMLElement).innerText.trim().replace('回', '') as string),
+            combo: parseInt((dom.querySelector('div.combo_cnt') as HTMLElement).innerText.trim().replace('回', '') as string),
+            hit: 0
+            /* eslint-enable */
+          }
 
-                    playdata.hit = playdata.good + playdata.ok + playdata.pound;
+          playdata.hit = playdata.good + playdata.ok + playdata.pound
 
-                    return playdata;
-                })()
-            }
-        })
+          return playdata
+        })()
+      }
     })
-
-    return;
+  })
 }

--- a/src/injections/dani.ts
+++ b/src/injections/dani.ts
@@ -1,53 +1,63 @@
-import { type SongData } from "../types";
+import { type PlaydataType, type SongData } from "../types";
 import BestScore from "../components/Dani/BestScore.svelte";
 
-export default async function dani():Promise<void>{
-    if((new URL(window.location.href)).pathname !== "/dan_detail.php") return;
+export default async function dani(): Promise<void> {
+    if ((new URL(window.location.href)).pathname !== "/dan_detail.php") return;
 
     const boxes = [...document.querySelectorAll('.contentBox:not(.errorArea)')];
     const songdata = (await import('../songdata.json') as any).default as Record<string, SongData>
 
-    await Promise.all(boxes.map(async(box) => {
-        const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim();
-        console.log(songTitle);
-        const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo;
-        const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, "$1")
-
-        if(songNo === undefined || difficulty === undefined) return;
-
-        let response:string;
-        try{
-            response = await (await fetch(`/score_detail.php?song_no=${songNo}&level=${difficulty}`)).text()
-        }
-        catch{
-            return;
-        }
-
-        const dom = document.createElement('div');
-        dom.innerHTML = response;
-        const scoreDetailTable = dom.querySelector('.scoreDetailTable');
-
-        if(scoreDetailTable === null) return;
-
-        const playdata = {
-            score: parseInt((dom.querySelector('.high_score') as HTMLElement).innerText.trim().replace('点', '')),
-            good: parseInt((dom.querySelector('.good_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-            ok: parseInt((dom.querySelector('.ok_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-            ng: parseInt((dom.querySelector('.ng_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-            pound: parseInt((dom.querySelector('.pound_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-            combo: parseInt((dom.querySelector('.combo_cnt') as HTMLElement).innerText.trim().replace('回', '')),
-            hit: 0
-        }
-
-        playdata.hit = playdata.good + playdata.ok + playdata.pound;
-
+    boxes.map((box) => {
         const bestscore = new BestScore({
             target: box,
-            props: {playdata}
-        })
+            props: {
+                playdata: (async () => {
+                    const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim();
+                    console.log(songTitle);
+                    const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo;
+                    const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, "$1")
 
-        return;
-    }))
+                    //db에 해당 곡명을 가진 곡에 대한 데이터가 없으면 종료
+                    if (songNo === undefined || difficulty === undefined) throw new Error();
+
+                    let response: string;
+                    try {
+                        response = await (await fetch(`/score_detail.php?song_no=${songNo}&level=${difficulty}`)).text()
+                    }
+                    catch {
+                        //요청에 문제가 생기면 종료
+                        throw new Error();
+                    }
+
+                    const dom = document.createElement('div');
+                    dom.innerHTML = response;
+                    const scoreDetailTable = dom.querySelector('.scoreDetailTable');
+
+                    //scoreDetailTable이 없으면 종료
+                    if (scoreDetailTable === null) throw new Error();
+                    /*
+                    한번도 플레이한 적이 없으면 종료
+                    그냥 0점으로 표시할거면 밑줄 지우세요
+                    */
+                    if (dom.querySelector('.contentBox.errorArea')) throw new Error();
+
+                    const playdata:PlaydataType = {
+                        score: parseInt((dom.querySelector('.high_score') as HTMLElement).innerText.trim().replace('点', '')),
+                        good: parseInt((dom.querySelector('.good_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+                        ok: parseInt((dom.querySelector('.ok_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+                        ng: parseInt((dom.querySelector('.ng_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+                        pound: parseInt((dom.querySelector('.pound_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+                        combo: parseInt((dom.querySelector('.combo_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+                        hit: 0
+                    }
+
+                    playdata.hit = playdata.good + playdata.ok + playdata.pound;
+
+                    return playdata;
+                })()
+            }
+        })
+    })
 
     return;
 }

--- a/src/injections/dani.ts
+++ b/src/injections/dani.ts
@@ -1,0 +1,53 @@
+import { type SongData } from "../types";
+import BestScore from "../components/Dani/BestScore.svelte";
+
+export default async function dani():Promise<void>{
+    if((new URL(window.location.href)).pathname !== "/dan_detail.php") return;
+
+    const boxes = [...document.querySelectorAll('.contentBox:not(.errorArea)')];
+    const songdata = (await import('../songdata.json') as any).default as Record<string, SongData>
+
+    await Promise.all(boxes.map(async(box) => {
+        const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim();
+        console.log(songTitle);
+        const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo;
+        const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, "$1")
+
+        if(songNo === undefined || difficulty === undefined) return;
+
+        let response:string;
+        try{
+            response = await (await fetch(`/score_detail.php?song_no=${songNo}&level=${difficulty}`)).text()
+        }
+        catch{
+            return;
+        }
+
+        const dom = document.createElement('div');
+        dom.innerHTML = response;
+        const scoreDetailTable = dom.querySelector('.scoreDetailTable');
+
+        if(scoreDetailTable === null) return;
+
+        const playdata = {
+            score: parseInt((dom.querySelector('.high_score') as HTMLElement).innerText.trim().replace('点', '')),
+            good: parseInt((dom.querySelector('.good_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+            ok: parseInt((dom.querySelector('.ok_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+            ng: parseInt((dom.querySelector('.ng_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+            pound: parseInt((dom.querySelector('.pound_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+            combo: parseInt((dom.querySelector('.combo_cnt') as HTMLElement).innerText.trim().replace('回', '')),
+            hit: 0
+        }
+
+        playdata.hit = playdata.good + playdata.ok + playdata.pound;
+
+        const bestscore = new BestScore({
+            target: box,
+            props: {playdata}
+        })
+
+        return;
+    }))
+
+    return;
+}

--- a/src/injections/dani.ts
+++ b/src/injections/dani.ts
@@ -1,11 +1,12 @@
-import { type PlaydataType, type SongData } from '../types'
+import { type PlaydataType } from '../types'
 import BestScore from '../components/Dani/BestScore.svelte'
+import { SongDB } from '../lib/songDB'
 
 export default async function dani (): Promise<void> {
   if ((new URL(window.location.href)).pathname !== '/dan_detail.php') return
 
   const boxes = [...document.querySelectorAll('.contentBox:not(.errorArea)')]
-  const songdata = (await import('../songdata.json') as any).default as Record<string, SongData>
+  const songdata = await SongDB.getInstance()
 
   boxes.forEach((box) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -15,8 +16,7 @@ export default async function dani (): Promise<void> {
         playdata: (async () => {
         // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
           const songTitle = (box.querySelector('.songName') as HTMLElement).innerText.trim()
-          console.log(songTitle)
-          const songNo = (Object.values(songdata).find(song => song.title === songTitle) as any)?.songNo
+          const songNo = songdata.getSongDataByTitle(songTitle)?.[0]
           const difficulty = box.querySelector('img')?.src.replace(/https:\/\/donderhiroba.jp\/image\/sp\/640\/level_icon_(.)_640.png/, '$1')
 
           // db에 해당 곡명을 가진 곡에 대한 데이터가 없으면 종료
@@ -38,9 +38,9 @@ export default async function dani (): Promise<void> {
           if (scoreDetailTable === null) throw new Error()
           /*
                     한번도 플레이한 적이 없으면 종료
-                    그냥 0점으로 표시할거면 밑줄 지우세요
+                    그냥 0으로 표시할거면 밑줄 지우세요
                     */
-          if (dom.querySelector('.contentBox.errorArea') === null) throw new Error()
+          if (dom.querySelector('.contentBox.errorArea') !== null) throw new Error()
 
           const playdata: PlaydataType = {
             /* eslint-disable */

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -29,10 +29,10 @@ export class SettingsStorage implements ExtensionSetting {
 
     const data = (await storage.get(STORAGE_KEY))[STORAGE_KEY] as ExtensionSetting
 
-    this.donderInfo = data.donderInfo ?? this.donderInfo ?? {}
-    this.preferringDifficulty = data.preferringDifficulty ?? this.preferringDifficulty
-    this.language = data.language ?? this.language
-    this.lastTabIndex = data.lastTabIndex ?? this.lastTabIndex
+    this.donderInfo = data?.donderInfo ?? this.donderInfo ?? {}
+    this.preferringDifficulty = data?.preferringDifficulty ?? this.preferringDifficulty
+    this.language = data?.language ?? this.language
+    this.lastTabIndex = data?.lastTabIndex ?? this.lastTabIndex
   }
 
   async save (): Promise<void> {

--- a/src/lib/songDB.ts
+++ b/src/lib/songDB.ts
@@ -28,11 +28,11 @@ export class SongDB {
     return this.songDataMap.get(songNo)
   }
 
-  getSongNoByTitle (title: string): number | undefined {
+  getSongNoByTitle (title: string): string | undefined {
     for (const songNo of this.songDataMap.keys()) {
       const song = this.songDataMap.get(songNo)
       if (song?.title === title) {
-        return parseInt(songNo)
+        return songNo
       }
     }
     return undefined

--- a/src/lib/songDB.ts
+++ b/src/lib/songDB.ts
@@ -27,4 +27,14 @@ export class SongDB {
   getSongData (songNo: string): SongData | undefined {
     return this.songDataMap.get(songNo)
   }
+
+  getSongDataByTitle (title: string): [number, SongData] | undefined {
+    for (const songNo of this.songDataMap.keys()) {
+      const song = this.songDataMap.get(songNo)
+      if (song?.title === title) {
+        return [parseInt(songNo), song]
+      }
+    }
+    return undefined
+  }
 }

--- a/src/lib/songDB.ts
+++ b/src/lib/songDB.ts
@@ -28,11 +28,11 @@ export class SongDB {
     return this.songDataMap.get(songNo)
   }
 
-  getSongDataByTitle (title: string): [number, SongData] | undefined {
+  getSongNoByTitle (title: string): number | undefined {
     for (const songNo of this.songDataMap.keys()) {
       const song = this.songDataMap.get(songNo)
       if (song?.title === title) {
-        return [parseInt(songNo), song]
+        return parseInt(songNo)
       }
     }
     return undefined

--- a/src/songdata.json
+++ b/src/songdata.json
@@ -43674,9 +43674,9 @@
       "oni_ura": 10.4
     },
     "songNo": "1197",
-    "title": "Re：End of a Dream",
-    "title_kr_official": "Re：End of a Dream",
-    "title_kr_user": "Re：End of a Dream",
+    "title": "Re ： End of a Dream",
+    "title_kr_official": "Re ： End of a Dream",
+    "title_kr_user": "Re ： End of a Dream",
     "artist": "uma vs. モリモリあつし",
     "composer": "",
     "balloonCounts": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,13 @@ export interface FavoriteSong {
   title: string
   genre: GenreType
 }
+
+export interface PlaydataType {
+  score: number;
+  good: number;
+  ok: number;
+  ng: number;
+  pound: number;
+  combo: number;
+  hit:number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,11 +85,11 @@ export interface FavoriteSong {
 }
 
 export interface PlaydataType {
-  score: number;
-  good: number;
-  ok: number;
-  ng: number;
-  pound: number;
-  combo: number;
-  hit:number;
+  score: number
+  good: number
+  ok: number
+  ng: number
+  pound: number
+  combo: number
+  hit: number
 }


### PR DESCRIPTION
- 크롬 설정 관련 에러 수정
- 단위도장 상세 페이지에서 각 과제곡의 연주 게임 베스트 스코어 및 기록을 표시
- `src/songdata.json`에 리엔드 곡명을 히로바와 똑같이 수정
- +eslint 형식에 맞게 수정

커밋에 "연습" 게임이라고 쓴 거는 오타입니다.
